### PR TITLE
Improve Monte Carlo integration docs

### DIFF
--- a/src/math/monte_carlo/monte_carlo_integration.rs
+++ b/src/math/monte_carlo/monte_carlo_integration.rs
@@ -1,6 +1,10 @@
 use rand::Rng;
 
-/// Performs Monte Carlo integration of the function `f` over the interval [a, b] using the specified number of samples.
+/// Performs Monte Carlo integration of the function `f` over the interval [a, b]
+/// using the specified number of samples.
+///
+/// Random samples are drawn from the half-open interval `[a, b)`, which is
+/// equivalent for continuous integrands.
 pub fn monte_carlo_integration<F>(f: F, a: f64, b: f64, samples: usize) -> f64
 where
     F: Fn(f64) -> f64,


### PR DESCRIPTION
## Summary
- clarify that Monte Carlo integration draws random samples from `[a, b)`
- note that this is equivalent for continuous integrands

## Testing
- `cargo test` *(fails: Could not connect to server)*